### PR TITLE
KUDU-1700: Debug build will not fail gracefully on Messenger::Init() …

### DIFF
--- a/src/kudu/rpc/messenger.h
+++ b/src/kudu/rpc/messenger.h
@@ -95,7 +95,6 @@ class MessengerBuilder {
   Status Build(std::shared_ptr<Messenger> *msgr);
 
  private:
-  Status Build(Messenger **msgr);
   const std::string name_;
   MonoDelta connection_keepalive_time_;
   int num_reactors_;


### PR DESCRIPTION
…failure

If Messenger::Init() fails in a debug build, a CHECK() will happen on
the destruction of the Messenger object. This happens beacuse, on an
error, the Messenger is not Shutdown().

This patch gets rid of the private function
Messenger::Build(Messenger**) and moves all its logic into the public
function Build(shared_ptr<Messenger>*). On an error, an explicit call
to AllExternalReferencesDropped() is made.

This case was probably never encountered as Messenger::Init()
currently has a very low chance of failing. However, in the future, as
more things may get added on to the function, this issue might show
up more often.

A more detailed explanation is given in the JIRA.

Change-Id: Id6021587c746af53305b3f601bb1bcc19f63eab0
Reviewed-on: http://gerrit.cloudera.org:8080/4724
Reviewed-by: Todd Lipcon <todd@apache.org>
Tested-by: Kudu Jenkins